### PR TITLE
Fixed GPIO_I2S_CLK and GPIO_I2S_LR defines - they were swapped

### DIFF
--- a/include/mch2022_badge.h
+++ b/include/mch2022_badge.h
@@ -15,9 +15,9 @@
 #define GPIO_UART_TX     1
 #define GPIO_SD_D0       2
 #define GPIO_UART_RX     3
-#define GPIO_I2S_LR      4
+#define GPIO_I2S_CLK     4
 #define GPIO_LED_DATA    5
-#define GPIO_I2S_CLK     12
+#define GPIO_I2S_LR      12
 #define GPIO_I2S_DATA    13
 #define GPIO_SD_CLK      14
 #define GPIO_SD_CMD      15


### PR DESCRIPTION
Pin defines for I2S LRCLK and BCLK were swapped (compared to schematics, tested in code). This change should not have an effect on the startup sound since the corresponding code does not use the pin defines.